### PR TITLE
feat: メニュー画面（MenuState）を実装

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -8,6 +8,7 @@ import { PixelRenderer } from '../rendering/PixelRenderer.js';
 import { LevelLoader } from '../levels/LevelLoader.js';
 import { Player } from '../entities/Player.js';
 import { MusicSystem } from '../audio/MusicSystem.js';
+import { MenuState } from '../states/MenuState.js';
 
 export class Game {
     constructor(canvas) {
@@ -67,6 +68,12 @@ export class Game {
             // クリックイベントで音楽を開始（ブラウザの自動再生ポリシー対応）
             this.setupAudioEvents();
             
+            // 状態を登録
+            this.registerStates();
+            
+            // メニュー状態から開始
+            this.stateManager.setState('menu');
+            
             console.log('Game initialized successfully!');
             return true;
         } catch (error) {
@@ -99,6 +106,15 @@ export class Game {
         
         // デバッグモードを有効にする
         this.renderer.setDebugMode(true);
+    }
+    
+    registerStates() {
+        // メニュー状態を登録
+        const menuState = new MenuState(this);
+        this.stateManager.registerState('menu', menuState);
+        
+        // TODO: PlayStateを実装後に追加
+        // this.stateManager.registerState('play', new PlayState(this));
     }
     
     setupAudioEvents() {
@@ -161,6 +177,17 @@ export class Game {
         // 入力の更新
         this.inputManager.update();
         
+        // 現在の状態に応じて処理を分岐
+        if (this.stateManager.currentStateName === 'menu') {
+            // メニュー状態の更新
+            this.stateManager.update(this.frameTime);
+        } else {
+            // ゲームプレイ状態の更新（テスト用）
+            this.updateTestMode();
+        }
+    }
+    
+    updateTestMode() {
         // テスト用ログ - 更新確認（デバッグモード時のみ）
         const input = this.inputManager.getInput();
         if (input.jump && this.debug) {
@@ -210,6 +237,17 @@ export class Game {
     }
     
     render() {
+        // 現在の状態に応じて描画を分岐
+        if (this.stateManager.currentStateName === 'menu') {
+            // メニュー状態の描画
+            this.stateManager.render(this.renderer);
+        } else {
+            // ゲームプレイ状態の描画（テスト用）
+            this.renderTestMode();
+        }
+    }
+    
+    renderTestMode() {
         // レンダラーでクリア
         this.renderer.clear('#5C94FC');
         
@@ -222,9 +260,6 @@ export class Game {
         if (this.player) {
             this.player.render(this.renderer);
         }
-        
-        // 状態管理の描画
-        this.stateManager.render(this.ctx);
         
         // デバッグ情報の表示
         this.renderDebugInfo();

--- a/src/rendering/PixelRenderer.js
+++ b/src/rendering/PixelRenderer.js
@@ -134,16 +134,20 @@ export class PixelRenderer {
      * @param {number} y - Y座標
      * @param {string} color - 色
      * @param {number} size - フォントサイズ
+     * @param {number} alpha - アルファ値（0-1）
      */
-    drawText(text, x, y, color = '#FFFFFF', size = 16) {
+    drawText(text, x, y, color = '#FFFFFF', size = 16, alpha = 1) {
         const drawX = Math.floor(x - this.cameraX);
         const drawY = Math.floor(y - this.cameraY);
         
+        this.ctx.save();
+        this.ctx.globalAlpha = alpha;
         this.ctx.fillStyle = color;
         this.ctx.font = `${size}px monospace`;
         this.ctx.textAlign = 'left';
         this.ctx.textBaseline = 'top';
         this.ctx.fillText(text, drawX, drawY);
+        this.ctx.restore();
     }
     
     /**
@@ -303,5 +307,34 @@ export class PixelRenderer {
         this.ctx.mozImageSmoothingEnabled = false;
         this.ctx.webkitImageSmoothingEnabled = false;
         this.ctx.msImageSmoothingEnabled = false;
+    }
+    
+    /**
+     * 塗りつぶし矩形を描画（カメラ無視）
+     * @param {number} x - X座標
+     * @param {number} y - Y座標
+     * @param {number} width - 幅
+     * @param {number} height - 高さ
+     * @param {string} color - 色
+     */
+    fillRect(x, y, width, height, color) {
+        this.ctx.fillStyle = color;
+        this.ctx.fillRect(x, y, width, height);
+    }
+    
+    /**
+     * 円を描画（線のみ）
+     * @param {number} x - 中心X座標
+     * @param {number} y - 中心Y座標
+     * @param {number} radius - 半径
+     * @param {string} color - 線の色
+     * @param {number} lineWidth - 線の太さ
+     */
+    strokeCircle(x, y, radius, color = '#FFFFFF', lineWidth = 1) {
+        this.ctx.strokeStyle = color;
+        this.ctx.lineWidth = lineWidth;
+        this.ctx.beginPath();
+        this.ctx.arc(x, y, radius, 0, Math.PI * 2);
+        this.ctx.stroke();
     }
 }

--- a/src/states/GameStateManager.js
+++ b/src/states/GameStateManager.js
@@ -46,12 +46,22 @@ export class GameStateManager {
         
         // 新しい状態を開始
         this.currentState = this.states.get(name);
+        this.currentStateName = name;
         if (this.currentState.enter) {
             this.currentState.enter(params);
         }
         
         // イベントを記録
         this.recordEvent('stateChange', { from: this.previousState?.name, to: name, params });
+    }
+    
+    /**
+     * 状態を切り替え（エイリアス）
+     * @param {string} name - 切り替え先の状態名
+     * @param {Object} params - 状態に渡すパラメータ
+     */
+    setState(name, params = {}) {
+        this.changeState(name, params);
     }
     
     /**
@@ -66,11 +76,11 @@ export class GameStateManager {
     
     /**
      * 現在の状態を描画
-     * @param {CanvasRenderingContext2D} ctx - 描画コンテキスト
+     * @param {PixelRenderer} renderer - レンダラー
      */
-    render(ctx) {
+    render(renderer) {
         if (this.currentState && this.currentState.render) {
-            this.currentState.render(ctx);
+            this.currentState.render(renderer);
         }
     }
     

--- a/src/states/MenuState.js
+++ b/src/states/MenuState.js
@@ -1,0 +1,381 @@
+/**
+ * メニュー画面の状態管理クラス
+ */
+export class MenuState {
+    constructor(game) {
+        this.game = game;
+        this.selectedOption = 0;
+        this.options = [
+            { text: 'START GAME', action: 'start' },
+            { text: 'HOW TO PLAY', action: 'howto' },
+            { text: 'CREDITS', action: 'credits' }
+        ];
+        
+        // アニメーション用
+        this.logoY = -100;
+        this.logoTargetY = 80;
+        this.optionsAlpha = 0;
+        this.enterPressed = false;
+        
+        // How to Play画面の状態
+        this.showHowTo = false;
+        this.showCredits = false;
+        
+        // タイトル画面のアニメーション
+        this.titleAnimTimer = 0;
+        this.coinAnimTimer = 0;
+        this.starAnimTimer = 0;
+    }
+    
+    /**
+     * 状態の初期化
+     */
+    init() {
+        // アニメーションをリセット
+        this.logoY = -100;
+        this.optionsAlpha = 0;
+        this.selectedOption = 0;
+        this.enterPressed = false;
+        this.showHowTo = false;
+        this.showCredits = false;
+        
+        // タイトルBGMを再生
+        if (this.game.musicSystem?.isInitialized) {
+            this.game.musicSystem.playTitleBGM();
+        }
+    }
+    
+    /**
+     * 状態に入った時の処理
+     */
+    enter() {
+        this.init();
+    }
+    
+    /**
+     * 更新処理
+     * @param {number} deltaTime - 経過時間
+     */
+    update(deltaTime) {
+        // アニメーションタイマー更新
+        this.titleAnimTimer += deltaTime;
+        this.coinAnimTimer += deltaTime;
+        this.starAnimTimer += deltaTime;
+        
+        // ロゴのアニメーション
+        if (this.logoY < this.logoTargetY) {
+            this.logoY += 5;
+            if (this.logoY > this.logoTargetY) {
+                this.logoY = this.logoTargetY;
+            }
+        }
+        
+        // オプションのフェードイン
+        if (this.logoY >= this.logoTargetY && this.optionsAlpha < 1) {
+            this.optionsAlpha += 0.02;
+            if (this.optionsAlpha > 1) {
+                this.optionsAlpha = 1;
+            }
+        }
+        
+        // 入力処理
+        // const input = this.game.inputManager.getInput();  // 現在は未使用
+        
+        if (this.showHowTo || this.showCredits) {
+            // How to Play/Credits画面での入力
+            if (this.game.inputManager.isKeyJustPressed('Escape') || 
+                this.game.inputManager.isKeyJustPressed('Enter') ||
+                this.game.inputManager.isKeyJustPressed('Space')) {
+                this.showHowTo = false;
+                this.showCredits = false;
+                if (this.game.musicSystem) {
+                    this.game.musicSystem.playButtonClickSound();
+                }
+            }
+        } else {
+            // メニュー選択
+            if (this.game.inputManager.isKeyJustPressed('ArrowUp') || 
+                this.game.inputManager.isKeyJustPressed('KeyW')) {
+                this.selectedOption--;
+                if (this.selectedOption < 0) {
+                    this.selectedOption = this.options.length - 1;
+                }
+                if (this.game.musicSystem) {
+                    this.game.musicSystem.playButtonClickSound();
+                }
+            }
+            
+            if (this.game.inputManager.isKeyJustPressed('ArrowDown') || 
+                this.game.inputManager.isKeyJustPressed('KeyS')) {
+                this.selectedOption++;
+                if (this.selectedOption >= this.options.length) {
+                    this.selectedOption = 0;
+                }
+                if (this.game.musicSystem) {
+                    this.game.musicSystem.playButtonClickSound();
+                }
+            }
+            
+            // 決定
+            if ((this.game.inputManager.isKeyJustPressed('Enter') || 
+                 this.game.inputManager.isKeyJustPressed('Space')) && 
+                 !this.enterPressed && this.optionsAlpha >= 1) {
+                this.enterPressed = true;
+                this.executeOption();
+            }
+        }
+    }
+    
+    /**
+     * 描画処理
+     * @param {PixelRenderer} renderer - レンダラー
+     */
+    render(renderer) {
+        // 背景
+        renderer.fillRect(0, 0, renderer.canvas.width, renderer.canvas.height, '#1a1a2e');
+        
+        // 装飾的な星背景
+        this.drawStarfield(renderer);
+        
+        if (this.showHowTo) {
+            this.renderHowToPlay(renderer);
+        } else if (this.showCredits) {
+            this.renderCredits(renderer);
+        } else {
+            // タイトルロゴ
+            this.drawTitleLogo(renderer);
+            
+            // メニューオプション
+            this.drawMenuOptions(renderer);
+            
+            // 装飾的なコイン
+            this.drawDecorativeCoins(renderer);
+        }
+        
+        // バージョン情報
+        renderer.drawText('v0.1.0 - Pixel Edition', 10, renderer.canvas.height - 10, '#666666', 10);
+    }
+    
+    /**
+     * タイトルロゴの描画
+     */
+    drawTitleLogo(renderer) {
+        const centerX = renderer.canvas.width / 2;
+        
+        // メインタイトル
+        const titleY = this.logoY;
+        renderer.drawText('COIN HUNTER', centerX - 120, titleY, '#FFD700', 48);
+        renderer.drawText('ADVENTURE', centerX - 90, titleY + 50, '#FF6B6B', 36);
+        
+        // Pixel Edition サブタイトル
+        renderer.drawText('- Pixel Edition -', centerX - 60, titleY + 90, '#4ECDC4', 16);
+        
+        // タイトルの影
+        renderer.drawText('COIN HUNTER', centerX - 118, titleY + 2, '#B8860B', 48);
+        renderer.drawText('ADVENTURE', centerX - 88, titleY + 52, '#CC5555', 36);
+    }
+    
+    /**
+     * メニューオプションの描画
+     */
+    drawMenuOptions(renderer) {
+        if (this.optionsAlpha <= 0) return;
+        
+        const centerX = renderer.canvas.width / 2;
+        const startY = 300;
+        const lineHeight = 50;
+        
+        this.options.forEach((option, index) => {
+            const y = startY + index * lineHeight;
+            const isSelected = index === this.selectedOption;
+            
+            // 選択中の項目の背景
+            if (isSelected) {
+                const pulse = Math.sin(this.titleAnimTimer * 0.005) * 0.3 + 0.7;
+                renderer.fillRect(
+                    centerX - 150, 
+                    y - 25, 
+                    300, 
+                    40, 
+                    `rgba(78, 205, 196, ${0.3 * pulse * this.optionsAlpha})`
+                );
+            }
+            
+            // テキスト
+            const color = isSelected ? '#FFD700' : '#FFFFFF';
+            const size = isSelected ? 24 : 20;
+            const offsetX = option.text.length * size / 4;
+            
+            renderer.drawText(
+                option.text, 
+                centerX - offsetX, 
+                y, 
+                color, 
+                size,
+                this.optionsAlpha
+            );
+            
+            // 選択カーソル
+            if (isSelected) {
+                const cursorX = centerX - offsetX - 30;
+                renderer.drawText('▶', cursorX + Math.sin(this.titleAnimTimer * 0.01) * 5, y, '#FFD700', 20);
+            }
+        });
+        
+        // 操作説明
+        renderer.drawText(
+            'Arrow Keys: Select   Enter/Space: Confirm', 
+            centerX - 150, 
+            450, 
+            '#999999', 
+            12,
+            this.optionsAlpha
+        );
+    }
+    
+    /**
+     * 星背景の描画
+     */
+    drawStarfield(renderer) {
+        const stars = 50;
+        for (let i = 0; i < stars; i++) {
+            const x = (i * 137) % renderer.canvas.width;
+            const y = (i * 89) % renderer.canvas.height;
+            const size = (i % 3) + 1;
+            const brightness = Math.sin(this.starAnimTimer * 0.001 + i) * 0.3 + 0.7;
+            const color = `rgba(255, 255, 255, ${brightness * 0.5})`;
+            
+            renderer.fillRect(x, y, size, size, color);
+        }
+    }
+    
+    /**
+     * 装飾的なコインの描画
+     */
+    drawDecorativeCoins(renderer) {
+        const coinPositions = [
+            { x: 100, y: 100, size: 16 },
+            { x: 700, y: 150, size: 20 },
+            { x: 150, y: 400, size: 18 },
+            { x: 650, y: 380, size: 16 }
+        ];
+        
+        coinPositions.forEach((pos, index) => {
+            const rotation = this.coinAnimTimer * 0.002 + index * Math.PI / 2;
+            const scale = Math.abs(Math.cos(rotation));
+            
+            renderer.strokeCircle(
+                pos.x, 
+                pos.y + Math.sin(this.coinAnimTimer * 0.001 + index) * 10, 
+                pos.size * scale, 
+                '#FFD700',
+                2
+            );
+            
+            // コインの中の文字
+            if (scale > 0.3) {
+                renderer.drawText(
+                    '¢', 
+                    pos.x - 5, 
+                    pos.y + 5 + Math.sin(this.coinAnimTimer * 0.001 + index) * 10, 
+                    '#FFD700', 
+                    16
+                );
+            }
+        });
+    }
+    
+    /**
+     * How to Play画面の描画
+     */
+    renderHowToPlay(renderer) {
+        const centerX = renderer.canvas.width / 2;
+        
+        // タイトル
+        renderer.drawText('HOW TO PLAY', centerX - 80, 50, '#FFD700', 32);
+        
+        // 操作説明
+        const instructions = [
+            { key: '← →', desc: 'Move left/right' },
+            { key: '↑ / Space', desc: 'Jump' },
+            { key: 'Hold Jump', desc: 'Jump higher' },
+            { key: 'M', desc: 'Toggle music' },
+            { key: '@', desc: 'Debug mode' }
+        ];
+        
+        let y = 150;
+        instructions.forEach(inst => {
+            renderer.drawText(inst.key, 200, y, '#4ECDC4', 18);
+            renderer.drawText(inst.desc, 350, y, '#FFFFFF', 16);
+            y += 40;
+        });
+        
+        // ゲーム説明
+        renderer.drawText('Collect all coins and reach the goal!', centerX - 150, 400, '#FFFFFF', 18);
+        renderer.drawText('Watch out for enemies and obstacles!', centerX - 150, 430, '#FF6B6B', 16);
+        
+        // 戻る説明
+        renderer.drawText('Press ESC/Enter/Space to return', centerX - 120, 500, '#999999', 14);
+    }
+    
+    /**
+     * Credits画面の描画
+     */
+    renderCredits(renderer) {
+        const centerX = renderer.canvas.width / 2;
+        
+        // タイトル
+        renderer.drawText('CREDITS', centerX - 50, 50, '#FFD700', 32);
+        
+        // クレジット内容
+        const credits = [
+            { role: 'Original Concept', name: 'SVG Version Team' },
+            { role: 'Pixel Edition', name: 'Canvas Development Team' },
+            { role: 'Music System', name: 'Web Audio API' },
+            { role: 'Special Thanks', name: 'All Players!' }
+        ];
+        
+        let y = 150;
+        credits.forEach(credit => {
+            renderer.drawText(credit.role, centerX - 100, y, '#4ECDC4', 16);
+            renderer.drawText(credit.name, centerX - 100, y + 25, '#FFFFFF', 14);
+            y += 70;
+        });
+        
+        // 戻る説明
+        renderer.drawText('Press ESC/Enter/Space to return', centerX - 120, 500, '#999999', 14);
+    }
+    
+    /**
+     * メニュー項目の実行
+     */
+    executeOption() {
+        const option = this.options[this.selectedOption];
+        
+        if (this.game.musicSystem) {
+            this.game.musicSystem.playGameStartSound();
+        }
+        
+        switch (option.action) {
+        case 'start':
+            // PlayStateへ遷移
+            this.game.stateManager.setState('play');
+            break;
+                
+        case 'howto':
+            this.showHowTo = true;
+            break;
+                
+        case 'credits':
+            this.showCredits = true;
+            break;
+        }
+    }
+    
+    /**
+     * 状態のクリーンアップ
+     */
+    destroy() {
+        // 特に必要なクリーンアップはなし
+    }
+}


### PR DESCRIPTION
## 概要
ゲームのメニュー画面を実装しました。

## 実装内容

### MenuStateクラス
- タイトルロゴとメニューオプションの表示
- キーボード操作によるメニュー選択（上下キーで選択、Enter/Spaceで決定）
- How to Play画面（操作説明）
- Credits画面（クレジット表示）

### アニメーション
- タイトルロゴのスライドイン
- メニューオプションのフェードイン
- 星背景のアニメーション
- 装飾的なコインの回転アニメーション
- 選択中の項目のパルスエフェクト

### 統合作業
- GameStateManagerとの連携
- 起動時にメニュー画面から開始
- 音楽システムとの連携（ボタン音）
- PixelRendererに円描画機能を追加

## 動作確認方法
1. `npm run dev` でゲームを起動
2. タイトル画面が表示される
3. 上下キーでメニュー項目を選択
4. Enter/Spaceで各項目を選択
   - START GAME: PlayState（未実装）へ遷移
   - HOW TO PLAY: 操作説明を表示
   - CREDITS: クレジットを表示

## 技術詳細
- 状態管理パターンに従った実装
- enter/update/render/exitのライフサイクル
- アニメーションタイマーによる演出制御

## 今後の課題
- PlayStateを実装後、START GAMEからの遷移を有効化
- メニュー選択時のトランジション効果
- 設定画面の追加（音量調整など）

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)