### PR TITLE
fix: Jekyllビルドエラーを修正 - vendorディレクトリを除外

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,10 +39,16 @@ jobs:
         env:
           JEKYLL_ENV: production
           
+      - name: Prepare deployment directory
+        run: |
+          # ドキュメントサイトのビルド結果をルートにコピー
+          mkdir -p _site
+          cp -r docs-site/_site/* _site/
+          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs-site/_site
+          path: ./_site
 
   deploy:
     environment:

--- a/docs-site/_config.yml
+++ b/docs-site/_config.yml
@@ -26,3 +26,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - vendor/


### PR DESCRIPTION
## 概要
GitHub PagesのJekyllビルドエラーとドキュメント表示の問題を修正します。

## 修正内容

### 1. Jekyllビルドエラーの修正
**エラー内容:**
```
Error: could not read file .../vendor/bundle/ruby/3.1.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: 
Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/3.1.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

**修正:**
`docs-site/_config.yml`の`exclude`設定に`vendor/`を追加

### 2. ドキュメントサイトの表示修正
**問題:**
- GitHub PagesのURLにアクセスすると、ドキュメントではなくゲームの`index.html`が表示されていた

**修正:**
- GitHub Actionsのワークフローを修正し、ビルド後のドキュメントをGitHub Pagesのルートディレクトリに配置するよう変更

## 変更ファイル
- `docs-site/_config.yml` - vendor/を除外リストに追加
- `.github/workflows/deploy-docs.yml` - デプロイディレクトリの準備ステップを追加

## 確認事項
- [x] _config.ymlに`vendor/`を追加
- [x] GitHub Actionsワークフローを修正
- [x] 他の設定に影響がないことを確認

マージ後、GitHub Pagesで正しくドキュメントサイトが表示されることを確認してください。