### PR TITLE
feat: プロジェクタイル発射音と敵ダメージ音の実装

### DIFF
--- a/src/config/ResourceLoader.ts
+++ b/src/config/ResourceLoader.ts
@@ -105,7 +105,7 @@ export class ResourceLoader {
         if (!this.resourceIndex) return;
         
         const bgmFiles = ['title', 'game', 'victory', 'gameover'];
-        const seFiles = ['coin', 'jump', 'damage', 'button', 'powerup', 'gameStart', 'goal', 'enemyDefeat'];
+        const seFiles = ['coin', 'jump', 'damage', 'button', 'powerup', 'gameStart', 'goal', 'enemyDefeat', 'projectile'];
         
         this.musicPatterns = {
             bgm: {},

--- a/src/config/resources/se/projectile.json
+++ b/src/config/resources/se/projectile.json
@@ -1,0 +1,27 @@
+{
+  "name": "Projectile",
+  "tracks": [
+    {
+      "instrument": {
+        "type": "square",
+        "volume": 0.4
+      },
+      "pattern": {
+        "notes": ["G5", "E5", "C5"],
+        "durations": [0.05, 0.05, 0.1],
+        "times": [0, 0.05, 0.1]
+      }
+    },
+    {
+      "instrument": {
+        "type": "sine",
+        "volume": 0.3
+      },
+      "pattern": {
+        "notes": ["C6", "G5"],
+        "durations": [0.08, 0.12],
+        "times": [0, 0.08]
+      }
+    }
+  ]
+}

--- a/src/config/resources/se/projectile.json
+++ b/src/config/resources/se/projectile.json
@@ -7,7 +7,7 @@
         "volume": 0.4
       },
       "pattern": {
-        "notes": ["G5", "E5", "C5"],
+        "notes": ["G3", "E3", "C3"],
         "durations": [0.05, 0.05, 0.1],
         "times": [0, 0.05, 0.1]
       }
@@ -18,7 +18,7 @@
         "volume": 0.3
       },
       "pattern": {
-        "notes": ["C6", "G5"],
+        "notes": ["C4", "G3"],
         "durations": [0.08, 0.12],
         "times": [0, 0.08]
       }

--- a/src/config/resources/se/projectile.json
+++ b/src/config/resources/se/projectile.json
@@ -7,7 +7,7 @@
         "volume": 0.4
       },
       "pattern": {
-        "notes": ["G3", "E3", "C3"],
+        "notes": ["G4", "E4", "C4"],
         "durations": [0.05, 0.05, 0.1],
         "times": [0, 0.05, 0.1]
       }
@@ -18,7 +18,7 @@
         "volume": 0.3
       },
       "pattern": {
-        "notes": ["C4", "G3"],
+        "notes": ["C5", "G4"],
         "durations": [0.08, 0.12],
         "times": [0, 0.08]
       }

--- a/src/data/bundledData.ts
+++ b/src/data/bundledData.ts
@@ -19,6 +19,7 @@ import seGameStart from '../config/resources/se/gameStart.json';
 import seGoal from '../config/resources/se/goal.json';
 import seJump from '../config/resources/se/jump.json';
 import sePowerup from '../config/resources/se/powerup.json';
+import seProjectile from '../config/resources/se/projectile.json';
 
 import stageList from '../levels/data/stages.json';
 import stage0_1 from '../levels/data/stage0-1.json';
@@ -55,6 +56,7 @@ export const bundledMusicData: Record<string, unknown> = {
     '/src/config/resources/se/goal.json': seGoal,
     '/src/config/resources/se/jump.json': seJump,
     '/src/config/resources/se/powerup.json': sePowerup,
+    '/src/config/resources/se/projectile.json': seProjectile,
 };
 
 export const bundledStageData: Record<string, unknown> = {

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -92,6 +92,14 @@ export class Enemy extends Entity {
         } else {
             this.state = 'hurt';
             this.stateTimer = 300;
+            
+            if (this.eventBus) {
+                this.eventBus.emit('enemy:damaged', {
+                    enemy: this,
+                    damage: amount,
+                    position: { x: this.x, y: this.y }
+                });
+            }
         }
     }
 

--- a/src/managers/EntityManager.ts
+++ b/src/managers/EntityManager.ts
@@ -28,6 +28,12 @@ interface GameServices {
     inputSystem: InputSystem;
 }
 
+interface EnemyDamagedEventData {
+    enemy: Enemy;
+    damage: number;
+    position: { x: number; y: number };
+}
+
 /**
  * Manages entity functionality
  */
@@ -60,7 +66,7 @@ export class EntityManager {
             }
         });
         
-        this.eventBus.on('enemy:damaged', (_data: unknown) => {
+        this.eventBus.on('enemy:damaged', (_data: EnemyDamagedEventData) => {
             if (this.musicSystem?.isInitialized) {
                 this.musicSystem.playSEFromPattern('damage');
             }

--- a/src/managers/EntityManager.ts
+++ b/src/managers/EntityManager.ts
@@ -60,6 +60,12 @@ export class EntityManager {
             }
         });
         
+        this.eventBus.on('enemy:damaged', (_data: unknown) => {
+            if (this.musicSystem?.isInitialized) {
+                this.musicSystem.playSEFromPattern('damage');
+            }
+        });
+        
         this.eventBus.on('entity:findPlayer', () => {
             return this.player;
         });

--- a/src/powerups/PowerGloveEffect.ts
+++ b/src/powerups/PowerGloveEffect.ts
@@ -89,7 +89,7 @@ export class PowerGloveEffect implements PowerUpEffect<Player> {
         
         const musicSystem = this.entityManager.getMusicSystem();
         if (musicSystem) {
-            musicSystem.playSEFromPattern('shoot');
+            musicSystem.playSEFromPattern('projectile');
         }
         
     }

--- a/src/states/SoundTestState.ts
+++ b/src/states/SoundTestState.ts
@@ -38,7 +38,8 @@ export class SoundTestState implements GameState {
         'powerup': 'powerup',
         'gamestart': 'gameStart',
         'goal': 'goal',
-        'enemydefeat': 'enemyDefeat'
+        'enemydefeat': 'enemyDefeat',
+        'projectile': 'projectile'
     };
     
     private static readonly UI_LAYOUT = {
@@ -70,7 +71,7 @@ export class SoundTestState implements GameState {
             },
             {
                 type: 'se',
-                items: ['COIN', 'JUMP', 'DAMAGE', 'BUTTON', 'POWERUP', 'GAMESTART', 'GOAL', 'ENEMYDEFEAT'],
+                items: ['COIN', 'JUMP', 'DAMAGE', 'BUTTON', 'POWERUP', 'GAMESTART', 'GOAL', 'ENEMYDEFEAT', 'PROJECTILE'],
                 currentIndex: 0
             },
             {


### PR DESCRIPTION
## 概要
Issue #185 の対応として、プロジェクタイル発射音と敵ダメージ音を実装しました。

## 実装内容
- プロジェクタイル発射音（projectile.json）を新規作成
- PowerGloveEffectでプロジェクタイル発射時に音を再生
- Enemy.tsに敵ダメージ時の音再生イベントを追加
- EntityManagerで敵ダメージイベントをリッスンしてダメージ音を再生
- サウンドテスト画面にprojectile音を追加

## テスト方法
1. サウンドテストで「PROJECTILE」音を確認
2. ゲーム内でパワーグローブを取得してプロジェクタイルを発射し、音が再生されることを確認
3. プロジェクタイルで敵にダメージを与えた際にダメージ音が再生されることを確認

## 関連Issue
- #185

🤖 Generated with [Claude Code](https://claude.ai/code)