### PR TITLE
fix: テストのログファイルが分散している問題を修正 #220

### DIFF
--- a/src/config/ResourceLoader.ts
+++ b/src/config/ResourceLoader.ts
@@ -61,30 +61,48 @@ export class ResourceLoader {
         const parallelStartTime = performance.now();
         
         const loadingPromises = [
-            this.loadSprites().then(() => {
-                const now = performance.now();
-                recordPhase('loadSprites', parallelStartTime, now);
-            }),
-            this.loadCharacters().then(() => {
-                const now = performance.now();
-                recordPhase('loadCharacters', parallelStartTime, now);
-            }),
-            this.loadAudio().then(() => {
-                const now = performance.now();
-                recordPhase('loadAudio', parallelStartTime, now);
-            }),
-            this.loadObjects().then(() => {
-                const now = performance.now();
-                recordPhase('loadObjects', parallelStartTime, now);
-            }),
-            this.loadMusicPatterns().then(() => {
-                const now = performance.now();
-                recordPhase('loadMusicPatterns', parallelStartTime, now);
-            }),
-            this.loadPhysics().then(() => {
-                const now = performance.now();
-                recordPhase('loadPhysics', parallelStartTime, now);
-            })
+            (() => {
+                const startTime = performance.now();
+                return this.loadSprites().then(() => {
+                    const endTime = performance.now();
+                    recordPhase('loadSprites', startTime, endTime);
+                });
+            })(),
+            (() => {
+                const startTime = performance.now();
+                return this.loadCharacters().then(() => {
+                    const endTime = performance.now();
+                    recordPhase('loadCharacters', startTime, endTime);
+                });
+            })(),
+            (() => {
+                const startTime = performance.now();
+                return this.loadAudio().then(() => {
+                    const endTime = performance.now();
+                    recordPhase('loadAudio', startTime, endTime);
+                });
+            })(),
+            (() => {
+                const startTime = performance.now();
+                return this.loadObjects().then(() => {
+                    const endTime = performance.now();
+                    recordPhase('loadObjects', startTime, endTime);
+                });
+            })(),
+            (() => {
+                const startTime = performance.now();
+                return this.loadMusicPatterns().then(() => {
+                    const endTime = performance.now();
+                    recordPhase('loadMusicPatterns', startTime, endTime);
+                });
+            })(),
+            (() => {
+                const startTime = performance.now();
+                return this.loadPhysics().then(() => {
+                    const endTime = performance.now();
+                    recordPhase('loadPhysics', startTime, endTime);
+                });
+            })()
         ];
         
         await Promise.all(loadingPromises);

--- a/tests/e2e/performance-baseline.cjs
+++ b/tests/e2e/performance-baseline.cjs
@@ -220,7 +220,7 @@ async function measurePerformanceBaseline() {
         if (csvData) {
             const fs = require('fs');
             const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-            const filename = `tests/logs/performance-baseline-${timestamp}.csv`;
+            const filename = path.join(__dirname, '..', 'logs', `performance-baseline-${timestamp}.csv`);
             fs.writeFileSync(filename, csvData);
             console.log(`\n📄 詳細データを保存: ${filename}`);
         }

--- a/tests/e2e/performance-baseline.cjs
+++ b/tests/e2e/performance-baseline.cjs
@@ -1,5 +1,6 @@
 const GameTestHelpers = require('./utils/GameTestHelpers.cjs');
 const testConfig = require('./utils/testConfig.cjs');
+const path = require('path');
 
 /**
  * パフォーマンスベースライン計測テスト

--- a/tests/e2e/utils/TestFramework.cjs
+++ b/tests/e2e/utils/TestFramework.cjs
@@ -13,10 +13,10 @@ class TestFramework {
         this.options = {
             headless: options.headless ?? true,
             devtools: options.devtools ?? false,
-            screenshotPath: options.screenshotPath ?? 'tests/screenshots',
+            screenshotPath: options.screenshotPath ?? path.join(__dirname, '../../screenshots'),
             timeout: options.timeout,
             logToFile: options.logToFile ?? true,
-            logPath: options.logPath ?? 'tests/logs',
+            logPath: options.logPath ?? path.join(__dirname, '../../logs'),
             ...options
         };
         


### PR DESCRIPTION
## Summary
- TestFramework.cjsのデフォルトログパスを相対パスから絶対パスに変更
- 既存のログファイルを統一ディレクトリに移動
- 関連するLintエラーを修正

## 修正内容

### 1. パスの統一化
- `TestFramework.cjs`の`logPath`と`screenshotPath`をプロジェクトルートベースの絶対パスに変更
  - 変更前: `'tests/logs'` (相対パス)
  - 変更後: `path.join(__dirname, '../../logs')` (プロジェクトルートからの絶対パス)
- `performance-baseline.cjs`のハードコードされたパスも同様に修正

### 2. 既存ファイルの移動
- `tests/e2e/tests/logs/` → `tests/logs/` に26ファイルを移動
- 空ディレクトリを削除

### 3. Lintエラーの修正
- `@typescript-eslint/no-explicit-any`: window.performanceMetricsの型を適切に定義
- `local-rules/no-standalone-comments`: 独立した行のコメントを削除
- index.tsにグローバル型定義を追加してany型を排除

## 動作確認
- ✅ 個別テスト実行で正しいディレクトリにログが保存されることを確認
- ✅ 並列テスト実行でも正常に動作することを確認（全20テスト成功）
- ✅ Lintチェックがパスすることを確認

## コミット履歴
1. `0c1df4f` - fix: テストのログファイルが分散している問題を修正
2. `37e9fb8` - fix: performance-baseline.cjsのログパスを相対パスから絶対パスに修正
3. `51a04f4` - fix: Lintエラーを修正

## 注意事項
**path.resolve()の使用について**
- 現在のコードは`path.resolve(this.options.logPath)`を使用していますが、これは問題ありません
- なぜなら、`this.options.logPath`は既に`path.join(__dirname, '../../logs')`という絶対パスになっているため
- `path.resolve()`はこの絶対パスをそのまま返します

Fixes #220

🤖 Generated with [Claude Code](https://claude.ai/code)