### PR TITLE
TypeScript型チェック強化 Phase 5: noImplicitThis と alwaysStrict の有効化

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,8 +32,8 @@
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
-    "noImplicitThis": false,
-    "alwaysStrict": false,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
     
     // Additional Checks
     "noUnusedLocals": false,


### PR DESCRIPTION
## 概要
TypeScript型チェック強化の第5段階として、noImplicitThis と alwaysStrict を有効化しました。

## 変更内容
- tsconfig.json で noImplicitThis: true を設定
- tsconfig.json で alwaysStrict: true を設定

## 結果
- 型エラー: 0件 ✅
- テスト: すべて成功 ✅
- ビルド: 正常完了 ✅

## 関連 Issue
- #249
- #241 (親Issue)

🤖 Generated with [Claude Code](https://claude.ai/code)