### PR TITLE
TypeScript型チェック強化 Phase 6: strict mode の完全有効化

### DIFF
--- a/src/audio/MusicSystem.ts
+++ b/src/audio/MusicSystem.ts
@@ -140,7 +140,7 @@ export class MusicSystem {
             const endTime = performance.now();
             Logger.log('[Performance] MusicSystem.init() failed:', endTime.toFixed(2) + 'ms', '(took', (endTime - startTime).toFixed(2) + 'ms)');
             Logger.log('[Performance] Error details:', error);
-            if (error.name === 'NotAllowedError') {
+            if (error instanceof Error && error.name === 'NotAllowedError') {
                 Logger.log('音楽システムはユーザー操作後に開始されます');
             } else {
                 Logger.warn('音楽システムの初期化エラー:', error);

--- a/src/core/GameCore.ts
+++ b/src/core/GameCore.ts
@@ -183,7 +183,8 @@ export class GameCore {
             Logger.log('[Performance] After MusicSystem.init():', performance.now().toFixed(2) + 'ms', '(took', (performance.now() - musicInitStartTime).toFixed(2) + 'ms)');
             Logger.log('GameCore: MusicSystem initialized');
         } catch (error) {
-            Logger.log('[Performance] MusicSystem init error:', error.message, 'at', performance.now().toFixed(2) + 'ms');
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            Logger.log('[Performance] MusicSystem init error:', errorMessage, 'at', performance.now().toFixed(2) + 'ms');
             Logger.warn('GameCore: MusicSystem initialization failed, continuing without audio:', error);
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,8 @@ async function startGame() {
             if (ctx) {
                 ctx.fillStyle = 'red';
                 ctx.font = '20px Arial';
-                ctx.fillText('Error: ' + error.message, 10, 30);
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                ctx.fillText('Error: ' + errorMessage, 10, 30);
             }
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,20 +25,13 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     
-    // Type Checking - 段階的に厳格化
-    "strict": false,
-    "noImplicitAny": true,  // Phase 1: 暗黙的なany型を禁止
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
+    // Type Checking
+    "strict": true,
     
     // Additional Checks
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noImplicitReturns": true,  // Phase 1: すべてのコードパスでの返却を強制
+    "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     
     // Skip Libraries


### PR DESCRIPTION
## 概要
TypeScript型チェック強化の最終段階として、`strict: true` を設定し、すべての strict オプションを統合的に有効化しました。

## 関連Issue
Closes #250
親Issue: #241

## 変更内容
### 1. tsconfig.json の更新
- `strict: true` を設定
- 個別の strict オプションを削除（strict: true に含まれるため）
- Phaseコメントを削除

### 2. 型エラーの修正（3箇所）
すべて catch ブロックでの error 型チェックに関するもの：
- **MusicSystem.ts:143** - `instanceof Error` チェックを追加
- **GameCore.ts:186** - error.message アクセス前に型チェック
- **index.ts:86** - error.message アクセス前に型チェック

## テスト結果
- ✅ 型チェック: エラーなし
- ✅ Lintチェック: 合格（TODO警告のみ）
- ✅ E2Eテスト: 全22件合格
- ✅ ビルド: 成功

## 確認事項
- [x] strict: true が有効化されている
- [x] すべての型エラーが解消されている
- [x] 既存のテストがすべてパスする
- [x] ビルドが正常に完了する

## 今後の展望
これでTypeScript strict mode への移行が完了しました。今後は：
- より厳密な型安全性が保証される
- 新規コードも strict mode の基準で書かれる
- 潜在的なバグの早期発見が可能に

🤖 Generated with [Claude Code](https://claude.ai/code)