### PR TITLE
feat: 全スプライトパターンを一覧表示するデバッグページを追加

### DIFF
--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -138,3 +138,70 @@ DebugOverlayが有効な状態で**O**キーを押すと、敵スポーンダイ
 
 1. DebugOverlayが表示されている状態でDキーを押す
 2. ステージリストが`stages.json`に正しく定義されているか確認
+
+## スプライトデバッグページ
+
+### 概要
+
+`sprite-debug.html`は、ゲーム内の全スプライトパターンとパレット情報を一覧表示するデバッグツールです。
+
+### アクセス方法
+
+開発サーバー起動後、以下のURLにアクセス：
+
+```
+http://localhost:3000/sprite-debug.html
+```
+
+### 主な機能
+
+#### 1. 全スプライトパターンの表示
+- **カテゴリ別表示**: player, enemies, items, terrain, environment, tiles, ui, powerups, projectiles, effects
+- **3倍拡大表示**: ゲーム内と同じスケールで表示
+- **固定サイズ枠**: 90x90pxの枠内に収めて見やすく配置
+
+#### 2. ステージパレット切り替え
+- 右上のドロップダウンで以下のパレットを切り替え可能：
+  - GRASSLAND（草原ステージ）
+  - CAVE（洞窟ステージ）
+
+#### 3. パレット情報の表示
+- **パレットインデックス**: 各スプライトの下に「P0」「P1」などの形式で表示
+- **カラーパレット**: 使用している4色をカラーボックスで可視化
+- **詳細情報**: カラーボックスにホバーするとインデックスとカラーコードを表示
+
+#### 4. 特殊な表示
+- **PLAYER (POWER)**: パワーアップ状態のプレイヤーを別パレットで表示
+- **敵キャラクター分類**:
+  - enemies/slime, enemies/bird: ENEMY_BASIC パレット
+  - enemies/bat, enemies/spider, enemies/armor_knight: ENEMY_SPECIAL パレット
+
+### 技術的な実装
+
+#### パレット情報の取得
+実際のエンティティクラスから直接パレット情報を取得：
+
+```javascript
+// ResourceLoaderを初期化
+const resourceLoader = ResourceLoader.getInstance();
+await resourceLoader.initialize();
+await resourceLoader.preloadEntityConfigs();
+
+// エンティティインスタンスからパレット取得
+const player = new Player(0, 0);
+const paletteIndex = player.getSpritePaletteIndex();
+```
+
+#### エンティティクラスが存在しないスプライト
+以下のスプライトはエンティティクラスが存在しないため、直接パレットインデックスを指定：
+- **environment**: 背景装飾用（cloud, tree）
+- **tiles**: タイル描画用（ground, spike）
+- **ui**: UI要素（heart）
+- **effects**: エフェクト表示用（shield）
+
+### 使用例
+
+1. 新しいスプライトを追加した際の色確認
+2. ステージごとのパレット変化の確認
+3. パレット設定のデバッグ
+4. スプライトアセットの一覧確認

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -176,6 +176,42 @@ npm run dev
 - 座標は整数値に丸める
 - PixelRenderer経由で描画
 
+## パレット管理
+
+### エンティティのパレット定義
+各エンティティクラスは`getSpritePaletteIndex()`メソッドでパレットインデックスを返す必要があります：
+
+```typescript
+// Entity.tsで抽象メソッドとして定義
+public abstract getSpritePaletteIndex(): number;
+
+// 各エンティティクラスで実装
+public override getSpritePaletteIndex(): number {
+    return SpritePaletteIndex.CHARACTER;
+}
+```
+
+### パレット情報の取得方法
+エンティティからパレット情報を取得する際は、ResourceLoaderの初期化が必要：
+
+```typescript
+// ResourceLoaderを初期化
+const resourceLoader = ResourceLoader.getInstance();
+await resourceLoader.initialize();
+await resourceLoader.preloadEntityConfigs();
+
+// エンティティインスタンスからパレット取得
+const entity = new Player(0, 0);
+const paletteIndex = entity.getSpritePaletteIndex();
+```
+
+### デバッグツール
+`sprite-debug.html`で全スプライトとパレット情報を確認可能：
+- URL: `http://localhost:3000/sprite-debug.html`
+- 全スプライトパターンの表示
+- ステージごとのパレット切り替え
+- パレットインデックスと色の可視化
+
 ## パフォーマンス
 - 不要な再描画を避ける
 - オブジェクトプールを使用

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -332,9 +332,9 @@
                             const color = paletteSystem.getColor('sprite', paletteIndex, colorIndex);
                             if (color) {
                                 const hex = color.replace('#', '');
-                                data[pixelIndex] = parseInt(hex.substr(0, 2), 16);
-                                data[pixelIndex + 1] = parseInt(hex.substr(2, 2), 16);
-                                data[pixelIndex + 2] = parseInt(hex.substr(4, 2), 16);
+                                data[pixelIndex] = parseInt(hex.substring(0, 2), 16);
+                                data[pixelIndex + 1] = parseInt(hex.substring(2, 4), 16);
+                                data[pixelIndex + 2] = parseInt(hex.substring(4, 6), 16);
                                 data[pixelIndex + 3] = 255;
                             }
                         } catch (e) {

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -157,6 +157,13 @@
                          'jump1', 'jump2', 'jump_small1', 'jump_small2'],
                 paletteIndex: SpritePaletteIndex.CHARACTER
             },
+            'player (POWER)': {
+                sprites: ['idle', 'idle_small', 'walk1', 'walk2', 'walk3', 'walk4', 
+                         'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
+                         'jump1', 'jump2', 'jump_small1', 'jump_small2'],
+                paletteIndex: SpritePaletteIndex.CHARACTER_POWERGLOVE,
+                spritePrefix: 'player/'
+            },
             'enemies': {
                 sprites: ['slime_idle1', 'slime_idle2', 'bird_fly1', 'bird_fly2',
                          'bat_hang', 'bat_fly1', 'bat_fly2', 
@@ -294,7 +301,9 @@
                 grid.className = 'sprites-grid';
                 
                 categoryData.sprites.forEach(spriteName => {
-                    const key = `${categoryName}/${spriteName}`;
+                    // spritePrefix がある場合はそれを使用、なければデフォルトのカテゴリ名を使用
+                    const prefix = categoryData.spritePrefix || categoryName.split(' ')[0];
+                    const key = `${prefix}/${spriteName}`;
                     const spriteData = spriteDataMap[key];
                     
                     if (spriteData) {

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -69,25 +69,35 @@
         
         .sprites-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-            gap: 15px;
+            grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+            gap: 20px;
         }
         
         .sprite-item {
-            background: #000;
-            border: 1px solid #666;
-            padding: 5px;
             text-align: center;
             position: relative;
         }
         
+        .sprite-frame {
+            background: #000;
+            border: 1px solid #666;
+            width: 90px;
+            height: 90px;
+            margin: 0 auto;
+            position: relative;
+            display: flex;
+            align-items: flex-end;
+            justify-content: center;
+            overflow: hidden;
+        }
+        
         .sprite-item canvas {
             display: block;
-            margin: 0 auto 5px;
             image-rendering: pixelated;
             image-rendering: -moz-crisp-edges;
             image-rendering: crisp-edges;
-            background: #111;
+            max-width: 100%;
+            max-height: 100%;
             width: auto;
             height: auto;
         }
@@ -97,6 +107,7 @@
             color: #aaa;
             word-break: break-all;
             line-height: 1.2;
+            margin-top: 5px;
         }
         
         .loading {
@@ -246,14 +257,19 @@
             const div = document.createElement('div');
             div.className = 'sprite-item';
             
+            const frame = document.createElement('div');
+            frame.className = 'sprite-frame';
+            
             const canvas = document.createElement('canvas');
             drawSprite(canvas, spriteData, paletteIndex);
+            
+            frame.appendChild(canvas);
             
             const label = document.createElement('div');
             label.className = 'sprite-name';
             label.textContent = name;
             
-            div.appendChild(canvas);
+            div.appendChild(frame);
             div.appendChild(label);
             
             return div;

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -88,6 +88,8 @@
             image-rendering: -moz-crisp-edges;
             image-rendering: crisp-edges;
             background: #111;
+            width: auto;
+            height: auto;
         }
         
         .sprite-name {
@@ -131,8 +133,8 @@
     </div>
 
     <script type="module">
-        import { spriteDataMap } from './dist/assets/sprites/spriteData.js';
-        import { PaletteSystem, STAGE_PALETTES, SpritePaletteIndex } from './dist/utils/pixelArtPalette.js';
+        import { spriteDataMap } from './src/assets/sprites/spriteData.ts';
+        import { PaletteSystem, STAGE_PALETTES, SpritePaletteIndex } from './src/utils/pixelArtPalette.ts';
         
         const paletteSystem = new PaletteSystem();
         let currentStage = 'grassland';
@@ -190,9 +192,11 @@
             const ctx = canvas.getContext('2d');
             const width = spriteData.width || spriteData.data[0].length;
             const height = spriteData.height || spriteData.data.length;
+            const scale = 3; // ゲーム内と同じ3倍表示
             
-            canvas.width = width;
-            canvas.height = height;
+            canvas.width = width * scale;
+            canvas.height = height * scale;
+            ctx.imageSmoothingEnabled = false;
             
             const imageData = ctx.createImageData(width, height);
             const data = imageData.data;
@@ -227,7 +231,15 @@
                 }
             }
             
-            ctx.putImageData(imageData, 0, 0);
+            // 一時的なCanvasに元サイズで描画
+            const tempCanvas = document.createElement('canvas');
+            tempCanvas.width = width;
+            tempCanvas.height = height;
+            const tempCtx = tempCanvas.getContext('2d');
+            tempCtx.putImageData(imageData, 0, 0);
+            
+            // メインCanvasに3倍に拡大して描画
+            ctx.drawImage(tempCanvas, 0, 0, width, height, 0, 0, width * scale, height * scale);
         }
         
         function createSpriteElement(name, spriteData, paletteIndex) {

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sprite Debug - All Patterns</title>
+    <style>
+        body {
+            font-family: monospace;
+            background: #222;
+            color: #fff;
+            padding: 20px;
+            margin: 0;
+        }
+        
+        h1 {
+            text-align: center;
+            color: #0f0;
+            text-shadow: 2px 2px 0 #000;
+        }
+        
+        .controls {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: #333;
+            padding: 15px;
+            border: 2px solid #0f0;
+            border-radius: 5px;
+            z-index: 1000;
+        }
+        
+        .controls label {
+            display: block;
+            margin-bottom: 5px;
+            color: #0f0;
+        }
+        
+        .controls select {
+            width: 150px;
+            padding: 5px;
+            background: #000;
+            color: #0f0;
+            border: 1px solid #0f0;
+            font-family: monospace;
+        }
+        
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding-right: 220px;
+        }
+        
+        .category {
+            margin-bottom: 40px;
+            background: #333;
+            padding: 15px;
+            border: 1px solid #555;
+            border-radius: 5px;
+        }
+        
+        .category h2 {
+            color: #0f0;
+            margin: 0 0 15px 0;
+            font-size: 18px;
+            border-bottom: 1px solid #0f0;
+            padding-bottom: 5px;
+        }
+        
+        .sprites-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+            gap: 15px;
+        }
+        
+        .sprite-item {
+            background: #000;
+            border: 1px solid #666;
+            padding: 5px;
+            text-align: center;
+            position: relative;
+        }
+        
+        .sprite-item canvas {
+            display: block;
+            margin: 0 auto 5px;
+            image-rendering: pixelated;
+            image-rendering: -moz-crisp-edges;
+            image-rendering: crisp-edges;
+            background: #111;
+        }
+        
+        .sprite-name {
+            font-size: 10px;
+            color: #aaa;
+            word-break: break-all;
+            line-height: 1.2;
+        }
+        
+        .loading {
+            text-align: center;
+            color: #ff0;
+            font-size: 24px;
+            padding: 50px;
+        }
+        
+        .error {
+            color: #f00;
+            background: #400;
+            padding: 10px;
+            margin: 10px 0;
+            border: 1px solid #f00;
+        }
+    </style>
+</head>
+<body>
+    <h1>SPRITE DEBUG - ALL PATTERNS</h1>
+    
+    <div class="controls">
+        <label for="stageSelect">STAGE PALETTE:</label>
+        <select id="stageSelect">
+            <option value="grassland">GRASSLAND</option>
+            <option value="cave">CAVE</option>
+        </select>
+    </div>
+    
+    <div class="container">
+        <div id="loading" class="loading">LOADING SPRITES...</div>
+        <div id="content" style="display: none;"></div>
+        <div id="error" class="error" style="display: none;"></div>
+    </div>
+
+    <script type="module">
+        import { spriteDataMap } from './dist/assets/sprites/spriteData.js';
+        import { PaletteSystem, STAGE_PALETTES, SpritePaletteIndex } from './dist/utils/pixelArtPalette.js';
+        
+        const paletteSystem = new PaletteSystem();
+        let currentStage = 'grassland';
+        
+        const categories = {
+            'player': {
+                sprites: ['idle', 'idle_small', 'walk1', 'walk2', 'walk3', 'walk4', 
+                         'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
+                         'jump1', 'jump2', 'jump_small1', 'jump_small2'],
+                paletteIndex: SpritePaletteIndex.CHARACTER
+            },
+            'enemies': {
+                sprites: ['slime_idle1', 'slime_idle2', 'bird_fly1', 'bird_fly2',
+                         'bat_hang', 'bat_fly1', 'bat_fly2', 
+                         'spider/spider_idle', 'spider/spider_walk1', 'spider/spider_walk2', 'spider/spider_thread',
+                         'armor_knight_idle', 'armor_knight_move'],
+                paletteIndex: SpritePaletteIndex.ENEMY_BASIC
+            },
+            'items': {
+                sprites: ['coin_spin1', 'coin_spin2', 'coin_spin3', 'coin_spin4'],
+                paletteIndex: SpritePaletteIndex.ITEMS
+            },
+            'terrain': {
+                sprites: ['spring', 'goal_flag', 'cloud_large', 'cloud_small', 'ground_tile',
+                         'falling_floor_normal', 'falling_floor_crack1', 'falling_floor_crack2', 'falling_floor_broken'],
+                paletteIndex: SpritePaletteIndex.TERRAIN_OBJECTS
+            },
+            'environment': {
+                sprites: ['cloud1', 'cloud2', 'tree1'],
+                paletteIndex: SpritePaletteIndex.ENVIRONMENT_NATURE
+            },
+            'tiles': {
+                sprites: ['ground', 'grass_ground', 'spike'],
+                paletteIndex: SpritePaletteIndex.TILES_GROUND
+            },
+            'ui': {
+                sprites: ['heart', 'heart_empty'],
+                paletteIndex: SpritePaletteIndex.UI_ELEMENTS
+            },
+            'powerups': {
+                sprites: ['shield_stone', 'power_glove'],
+                paletteIndex: SpritePaletteIndex.POWERUPS
+            },
+            'projectiles': {
+                sprites: ['energy_bullet'],
+                paletteIndex: SpritePaletteIndex.EFFECTS
+            },
+            'effects': {
+                sprites: ['shield_left', 'shield_right'],
+                paletteIndex: SpritePaletteIndex.EFFECTS
+            }
+        };
+        
+        function drawSprite(canvas, spriteData, paletteIndex) {
+            const ctx = canvas.getContext('2d');
+            const width = spriteData.width || spriteData.data[0].length;
+            const height = spriteData.height || spriteData.data.length;
+            
+            canvas.width = width;
+            canvas.height = height;
+            
+            const imageData = ctx.createImageData(width, height);
+            const data = imageData.data;
+            
+            for (let y = 0; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                    const pixelIndex = (y * width + x) * 4;
+                    const colorIndex = spriteData.data[y][x];
+                    
+                    if (colorIndex === 0) {
+                        data[pixelIndex] = 0;
+                        data[pixelIndex + 1] = 0;
+                        data[pixelIndex + 2] = 0;
+                        data[pixelIndex + 3] = 0;
+                    } else {
+                        try {
+                            const color = paletteSystem.getColor('sprite', paletteIndex, colorIndex);
+                            if (color) {
+                                const hex = color.replace('#', '');
+                                data[pixelIndex] = parseInt(hex.substr(0, 2), 16);
+                                data[pixelIndex + 1] = parseInt(hex.substr(2, 2), 16);
+                                data[pixelIndex + 2] = parseInt(hex.substr(4, 2), 16);
+                                data[pixelIndex + 3] = 255;
+                            }
+                        } catch (e) {
+                            data[pixelIndex] = 255;
+                            data[pixelIndex + 1] = 0;
+                            data[pixelIndex + 2] = 255;
+                            data[pixelIndex + 3] = 255;
+                        }
+                    }
+                }
+            }
+            
+            ctx.putImageData(imageData, 0, 0);
+        }
+        
+        function createSpriteElement(name, spriteData, paletteIndex) {
+            const div = document.createElement('div');
+            div.className = 'sprite-item';
+            
+            const canvas = document.createElement('canvas');
+            drawSprite(canvas, spriteData, paletteIndex);
+            
+            const label = document.createElement('div');
+            label.className = 'sprite-name';
+            label.textContent = name;
+            
+            div.appendChild(canvas);
+            div.appendChild(label);
+            
+            return div;
+        }
+        
+        function renderAllSprites() {
+            const content = document.getElementById('content');
+            content.innerHTML = '';
+            
+            const stagePalette = paletteSystem.createStagePalette(STAGE_PALETTES[currentStage]);
+            paletteSystem.setStagePalette(stagePalette);
+            
+            Object.entries(categories).forEach(([categoryName, categoryData]) => {
+                const categoryDiv = document.createElement('div');
+                categoryDiv.className = 'category';
+                
+                const title = document.createElement('h2');
+                title.textContent = categoryName.toUpperCase();
+                categoryDiv.appendChild(title);
+                
+                const grid = document.createElement('div');
+                grid.className = 'sprites-grid';
+                
+                categoryData.sprites.forEach(spriteName => {
+                    const key = `${categoryName}/${spriteName}`;
+                    const spriteData = spriteDataMap[key];
+                    
+                    if (spriteData) {
+                        const element = createSpriteElement(spriteName, spriteData, categoryData.paletteIndex);
+                        grid.appendChild(element);
+                    }
+                });
+                
+                categoryDiv.appendChild(grid);
+                content.appendChild(categoryDiv);
+            });
+        }
+        
+        function init() {
+            try {
+                renderAllSprites();
+                
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('content').style.display = 'block';
+                
+                document.getElementById('stageSelect').addEventListener('change', (e) => {
+                    currentStage = e.target.value;
+                    renderAllSprites();
+                });
+                
+            } catch (error) {
+                console.error('Error initializing sprite debug:', error);
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('error').style.display = 'block';
+                document.getElementById('error').textContent = `ERROR: ${error.message}`;
+            }
+        }
+        
+        init();
+    </script>
+</body>
+</html>

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -110,6 +110,44 @@
             margin-top: 5px;
         }
         
+        .palette-info {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 5px;
+            margin-top: 3px;
+            font-size: 9px;
+            color: #888;
+        }
+        
+        .palette-colors {
+            display: flex;
+            gap: 2px;
+        }
+        
+        .palette-color {
+            width: 12px;
+            height: 12px;
+            border: 1px solid #444;
+            position: relative;
+            cursor: pointer;
+        }
+        
+        .palette-color:hover::after {
+            content: attr(data-index);
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #000;
+            color: #0f0;
+            padding: 2px 4px;
+            font-size: 8px;
+            white-space: nowrap;
+            border: 1px solid #0f0;
+            z-index: 1000;
+        }
+        
         .loading {
             text-align: center;
             color: #ff0;
@@ -146,70 +184,125 @@
     <script type="module">
         import { spriteDataMap } from './src/assets/sprites/spriteData.ts';
         import { PaletteSystem, STAGE_PALETTES, SpritePaletteIndex } from './src/utils/pixelArtPalette.ts';
+        import { ResourceLoader } from './src/config/ResourceLoader.ts';
+        
+        // エンティティクラスをインポート
+        import { Player } from './src/entities/Player.ts';
+        import { Slime } from './src/entities/enemies/Slime.ts';
+        import { Bat } from './src/entities/enemies/Bat.ts';
+        import { Spider } from './src/entities/enemies/Spider.ts';
+        import { ArmorKnight } from './src/entities/enemies/ArmorKnight.ts';
+        import { Coin } from './src/entities/Coin.ts';
+        import { Spring } from './src/entities/Spring.ts';
+        import { GoalFlag } from './src/entities/GoalFlag.ts';
+        import { FallingFloor } from './src/entities/FallingFloor.ts';
+        import { ShieldStone } from './src/entities/powerups/ShieldStone.ts';
+        import { PowerGlove } from './src/entities/powerups/PowerGlove.ts';
+        import { EnergyBullet } from './src/entities/projectiles/EnergyBullet.ts';
         
         const paletteSystem = new PaletteSystem();
         let currentStage = 'grassland';
         
-        const categories = {
-            'player': {
-                sprites: ['idle', 'idle_small', 'walk1', 'walk2', 'walk3', 'walk4', 
-                         'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
-                         'jump1', 'jump2', 'jump_small1', 'jump_small2'],
-                paletteIndex: SpritePaletteIndex.CHARACTER
-            },
-            'player (POWER)': {
-                sprites: ['idle', 'idle_small', 'walk1', 'walk2', 'walk3', 'walk4', 
-                         'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
-                         'jump1', 'jump2', 'jump_small1', 'jump_small2'],
-                paletteIndex: SpritePaletteIndex.CHARACTER_POWERGLOVE,
-                spritePrefix: 'player'
-            },
-            'enemies (BASIC)': {
-                sprites: ['slime_idle1', 'slime_idle2', 'bird_fly1', 'bird_fly2'],
-                paletteIndex: SpritePaletteIndex.ENEMY_BASIC,
-                spritePrefix: 'enemies'
-            },
-            'enemies (SPECIAL)': {
-                sprites: ['bat_hang', 'bat_fly1', 'bat_fly2', 
-                         'spider/spider_idle', 'spider/spider_walk1', 'spider/spider_walk2', 'spider/spider_thread',
-                         'armor_knight_idle', 'armor_knight_move'],
-                paletteIndex: SpritePaletteIndex.ENEMY_SPECIAL,
-                spritePrefix: 'enemies'
-            },
-            'items': {
-                sprites: ['coin_spin1', 'coin_spin2', 'coin_spin3', 'coin_spin4'],
-                paletteIndex: SpritePaletteIndex.ITEMS
-            },
-            'terrain': {
-                sprites: ['spring', 'goal_flag', 'cloud_large', 'cloud_small', 'ground_tile',
-                         'falling_floor_normal', 'falling_floor_crack1', 'falling_floor_crack2', 'falling_floor_broken'],
-                paletteIndex: SpritePaletteIndex.TERRAIN_OBJECTS
-            },
-            'environment': {
-                sprites: ['cloud1', 'cloud2', 'tree1'],
-                paletteIndex: SpritePaletteIndex.ENVIRONMENT_NATURE
-            },
-            'tiles': {
-                sprites: ['ground', 'grass_ground', 'spike'],
-                paletteIndex: SpritePaletteIndex.TILES_GROUND
-            },
-            'ui': {
-                sprites: ['heart', 'heart_empty'],
-                paletteIndex: SpritePaletteIndex.UI_ELEMENTS
-            },
-            'powerups': {
-                sprites: ['shield_stone', 'power_glove'],
-                paletteIndex: SpritePaletteIndex.POWERUPS
-            },
-            'projectiles': {
-                sprites: ['energy_bullet'],
-                paletteIndex: SpritePaletteIndex.EFFECTS
-            },
-            'effects': {
-                sprites: ['shield_left', 'shield_right'],
-                paletteIndex: SpritePaletteIndex.EFFECTS
-            }
-        };
+        // ResourceLoaderを初期化
+        async function initializeAndRender() {
+            const resourceLoader = ResourceLoader.getInstance();
+            await resourceLoader.initialize();
+            await resourceLoader.preloadEntityConfigs();
+            
+            // エンティティインスタンスを作成してパレット情報を取得
+            const tempPlayer = new Player(0, 0);
+            const tempPlayerPower = new Player(0, 0);
+            tempPlayerPower.hasPowerGlove = true;
+            const tempSlime = new Slime(0, 0);
+            const tempBat = new Bat(0, 0);
+            const tempSpider = new Spider(0, 0);
+            const tempArmorKnight = new ArmorKnight(0, 0);
+            const tempCoin = new Coin(0, 0);
+            const tempSpring = new Spring(0, 0);
+            const tempGoalFlag = new GoalFlag(0, 0);
+            const tempFallingFloor = new FallingFloor(0, 0);
+            const tempShieldStone = new ShieldStone(0, 0);
+            const tempPowerGlove = new PowerGlove(0, 0);
+            const tempEnergyBullet = new EnergyBullet(0, 0, { x: 1, y: 0 }, null);
+            
+            window.categories = {
+                'player': {
+                    sprites: ['idle', 'idle_small', 'walk1', 'walk2', 'walk3', 'walk4', 
+                             'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
+                             'jump1', 'jump2', 'jump_small1', 'jump_small2'],
+                    paletteIndex: tempPlayer.getSpritePaletteIndex()
+                },
+                'player (POWER)': {
+                    sprites: ['idle', 'idle_small', 'walk1', 'walk2', 'walk3', 'walk4', 
+                             'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
+                             'jump1', 'jump2', 'jump_small1', 'jump_small2'],
+                    paletteIndex: tempPlayerPower.getSpritePaletteIndex(),
+                    spritePrefix: 'player'
+                },
+                'enemies/slime': {
+                    sprites: ['slime_idle1', 'slime_idle2'],
+                    paletteIndex: tempSlime.getSpritePaletteIndex(),
+                    spritePrefix: 'enemies'
+                },
+                'enemies/bat': {
+                    sprites: ['bat_hang', 'bat_fly1', 'bat_fly2'],
+                    paletteIndex: tempBat.getSpritePaletteIndex(),
+                    spritePrefix: 'enemies'
+                },
+                'enemies/spider': {
+                    sprites: ['spider/spider_idle', 'spider/spider_walk1', 'spider/spider_walk2', 'spider/spider_thread'],
+                    paletteIndex: tempSpider.getSpritePaletteIndex(),
+                    spritePrefix: 'enemies'
+                },
+                'enemies/armor_knight': {
+                    sprites: ['armor_knight_idle', 'armor_knight_move'],
+                    paletteIndex: tempArmorKnight.getSpritePaletteIndex(),
+                    spritePrefix: 'enemies'
+                },
+                'enemies/bird': {
+                    sprites: ['bird_fly1', 'bird_fly2'],
+                    paletteIndex: SpritePaletteIndex.ENEMY_BASIC,
+                    spritePrefix: 'enemies'
+                },
+                'items': {
+                    sprites: ['coin_spin1', 'coin_spin2', 'coin_spin3', 'coin_spin4'],
+                    paletteIndex: tempCoin.getSpritePaletteIndex()
+                },
+                'terrain': {
+                    sprites: ['spring', 'goal_flag', 'cloud_large', 'cloud_small', 'ground_tile',
+                             'falling_floor_normal', 'falling_floor_crack1', 'falling_floor_crack2', 'falling_floor_broken'],
+                    paletteIndex: tempSpring.getSpritePaletteIndex()
+                },
+                'environment': {
+                    sprites: ['cloud1', 'cloud2', 'tree1'],
+                    paletteIndex: SpritePaletteIndex.ENVIRONMENT_NATURE
+                },
+                'tiles': {
+                    sprites: ['ground', 'grass_ground', 'spike'],
+                    paletteIndex: SpritePaletteIndex.TILES_GROUND
+                },
+                'ui': {
+                    sprites: ['heart', 'heart_empty'],
+                    paletteIndex: SpritePaletteIndex.UI_ELEMENTS
+                },
+                'powerups': {
+                    sprites: ['shield_stone', 'power_glove'],
+                    paletteIndex: tempShieldStone.getSpritePaletteIndex()
+                },
+                'projectiles': {
+                    sprites: ['energy_bullet'],
+                    paletteIndex: tempEnergyBullet.getSpritePaletteIndex()
+                },
+                'effects': {
+                    sprites: ['shield_left', 'shield_right'],
+                    paletteIndex: SpritePaletteIndex.EFFECTS
+                }
+            };
+            
+            renderAllSprites();
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('content').style.display = 'block';
+        }
         
         function drawSprite(canvas, spriteData, paletteIndex) {
             const ctx = canvas.getContext('2d');
@@ -284,6 +377,39 @@
             div.appendChild(frame);
             div.appendChild(label);
             
+            // パレット情報を追加
+            const paletteInfo = document.createElement('div');
+            paletteInfo.className = 'palette-info';
+            
+            const paletteIndexLabel = document.createElement('span');
+            paletteIndexLabel.textContent = `P${paletteIndex}:`;
+            paletteInfo.appendChild(paletteIndexLabel);
+            
+            const paletteColors = document.createElement('div');
+            paletteColors.className = 'palette-colors';
+            
+            // スプライトパレットの色を表示（4色）
+            for (let i = 0; i < 4; i++) {
+                try {
+                    const color = paletteSystem.getColor('sprite', paletteIndex, i);
+                    const colorDiv = document.createElement('div');
+                    colorDiv.className = 'palette-color';
+                    colorDiv.style.backgroundColor = color || 'transparent';
+                    colorDiv.setAttribute('data-index', `${i}: ${color || 'transparent'}`);
+                    paletteColors.appendChild(colorDiv);
+                } catch (e) {
+                    // エラーの場合は透明
+                    const colorDiv = document.createElement('div');
+                    colorDiv.className = 'palette-color';
+                    colorDiv.style.backgroundColor = 'transparent';
+                    colorDiv.setAttribute('data-index', `${i}: error`);
+                    paletteColors.appendChild(colorDiv);
+                }
+            }
+            
+            paletteInfo.appendChild(paletteColors);
+            div.appendChild(paletteInfo);
+            
             return div;
         }
         
@@ -294,7 +420,7 @@
             const stagePalette = paletteSystem.createStagePalette(STAGE_PALETTES[currentStage]);
             paletteSystem.setStagePalette(stagePalette);
             
-            Object.entries(categories).forEach(([categoryName, categoryData]) => {
+            Object.entries(window.categories).forEach(([categoryName, categoryData]) => {
                 const categoryDiv = document.createElement('div');
                 categoryDiv.className = 'category';
                 
@@ -324,14 +450,17 @@
         
         function init() {
             try {
-                renderAllSprites();
-                
-                document.getElementById('loading').style.display = 'none';
-                document.getElementById('content').style.display = 'block';
-                
                 document.getElementById('stageSelect').addEventListener('change', (e) => {
                     currentStage = e.target.value;
                     renderAllSprites();
+                });
+                
+                // ResourceLoaderを初期化してからレンダリング
+                initializeAndRender().catch(error => {
+                    console.error('Error initializing sprite debug:', error);
+                    document.getElementById('loading').style.display = 'none';
+                    document.getElementById('error').style.display = 'block';
+                    document.getElementById('error').textContent = `ERROR: ${error.message}`;
                 });
                 
             } catch (error) {

--- a/sprite-debug.html
+++ b/sprite-debug.html
@@ -162,14 +162,19 @@
                          'walk_small1', 'walk_small2', 'walk_small3', 'walk_small4',
                          'jump1', 'jump2', 'jump_small1', 'jump_small2'],
                 paletteIndex: SpritePaletteIndex.CHARACTER_POWERGLOVE,
-                spritePrefix: 'player/'
+                spritePrefix: 'player'
             },
-            'enemies': {
-                sprites: ['slime_idle1', 'slime_idle2', 'bird_fly1', 'bird_fly2',
-                         'bat_hang', 'bat_fly1', 'bat_fly2', 
+            'enemies (BASIC)': {
+                sprites: ['slime_idle1', 'slime_idle2', 'bird_fly1', 'bird_fly2'],
+                paletteIndex: SpritePaletteIndex.ENEMY_BASIC,
+                spritePrefix: 'enemies'
+            },
+            'enemies (SPECIAL)': {
+                sprites: ['bat_hang', 'bat_fly1', 'bat_fly2', 
                          'spider/spider_idle', 'spider/spider_walk1', 'spider/spider_walk2', 'spider/spider_thread',
                          'armor_knight_idle', 'armor_knight_move'],
-                paletteIndex: SpritePaletteIndex.ENEMY_BASIC
+                paletteIndex: SpritePaletteIndex.ENEMY_SPECIAL,
+                spritePrefix: 'enemies'
             },
             'items': {
                 sprites: ['coin_spin1', 'coin_spin2', 'coin_spin3', 'coin_spin4'],
@@ -302,7 +307,7 @@
                 
                 categoryData.sprites.forEach(spriteName => {
                     // spritePrefix がある場合はそれを使用、なければデフォルトのカテゴリ名を使用
-                    const prefix = categoryData.spritePrefix || categoryName.split(' ')[0];
+                    const prefix = categoryData.spritePrefix || categoryName.split(' ')[0].toLowerCase();
                     const key = `${prefix}/${spriteName}`;
                     const spriteData = spriteDataMap[key];
                     

--- a/src/entities/Coin.ts
+++ b/src/entities/Coin.ts
@@ -128,7 +128,7 @@ export class Coin extends Entity implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.ITEMS;
     }
 }

--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -189,7 +189,7 @@ export abstract class Entity {
      * Returns the sprite palette index for this entity
      * Must be implemented in derived classes
      */
-    protected abstract getSpritePaletteIndex(): number;
+    public abstract getSpritePaletteIndex(): number;
 
 
     renderDebug(renderer: PixelRenderer): void {

--- a/src/entities/FallingFloor.ts
+++ b/src/entities/FallingFloor.ts
@@ -223,7 +223,7 @@ export class FallingFloor extends Entity implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.TERRAIN_OBJECTS;
     }
 }

--- a/src/entities/GoalFlag.ts
+++ b/src/entities/GoalFlag.ts
@@ -92,7 +92,7 @@ export class GoalFlag extends Entity implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.TERRAIN_OBJECTS;
     }
 }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -720,7 +720,7 @@ export class Player extends Entity {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return this.hasPowerGlove ? SpritePaletteIndex.CHARACTER_POWERGLOVE : SpritePaletteIndex.CHARACTER;
     }
 }

--- a/src/entities/Spring.ts
+++ b/src/entities/Spring.ts
@@ -179,7 +179,7 @@ export class Spring extends Entity implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.TERRAIN_OBJECTS;
     }
 }

--- a/src/entities/enemies/ArmorKnight.ts
+++ b/src/entities/enemies/ArmorKnight.ts
@@ -231,7 +231,7 @@ export class ArmorKnight extends Enemy implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.ENEMY_SPECIAL;
     }
 }

--- a/src/entities/enemies/Bat.ts
+++ b/src/entities/enemies/Bat.ts
@@ -239,7 +239,7 @@ export class Bat extends Enemy implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.ENEMY_SPECIAL;
     }
 }

--- a/src/entities/enemies/Slime.ts
+++ b/src/entities/enemies/Slime.ts
@@ -117,7 +117,7 @@ export class Slime extends Enemy implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.ENEMY_BASIC;
     }
 }

--- a/src/entities/enemies/Spider.ts
+++ b/src/entities/enemies/Spider.ts
@@ -351,7 +351,7 @@ export class Spider extends Enemy implements EntityInitializer {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.ENEMY_SPECIAL;
     }
 }

--- a/src/entities/powerups/PowerUpItem.ts
+++ b/src/entities/powerups/PowerUpItem.ts
@@ -147,7 +147,7 @@ export abstract class PowerUpItem extends Entity implements EntityInitializer {
     /**
      * Returns the sprite palette index for power-up items
      */
-    protected getSpritePaletteIndex(): number {
+    public getSpritePaletteIndex(): number {
         return SpritePaletteIndex.POWERUPS;
     }
 }

--- a/src/entities/powerups/ShieldStone.ts
+++ b/src/entities/powerups/ShieldStone.ts
@@ -68,7 +68,7 @@ export class ShieldStone extends PowerUpItem {
     }
     
     
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.POWERUPS;
     }
 }

--- a/src/entities/projectiles/EnergyBullet.ts
+++ b/src/entities/projectiles/EnergyBullet.ts
@@ -148,7 +148,7 @@ export class EnergyBullet extends Entity implements EntityInitializer {
     /**
      * Returns the sprite palette index for energy bullet
      */
-    protected override getSpritePaletteIndex(): number {
+    public override getSpritePaletteIndex(): number {
         return SpritePaletteIndex.EFFECTS;
     }
 }


### PR DESCRIPTION
## 概要
Issue #283 の対応として、全スプライトパターンを一覧表示するデバッグページを作成しました。

## 変更内容
- `sprite-debug.html` を新規作成
- 全てのスプライトパターンをカテゴリ別に表示
- ステージパレット切り替え機能を実装

## 機能詳細
### スプライトカテゴリ
- **player**: idle, walk, jump の各パターン（通常/small）
- **enemies**: slime, bird, bat, spider, armor_knight の各パターン
- **items**: coin のアニメーションパターン
- **terrain**: spring, goal_flag, cloud, falling_floor など
- **environment**: cloud, tree
- **tiles**: ground, grass_ground, spike
- **ui**: heart, heart_empty
- **powerups**: shield_stone, power_glove
- **projectiles**: energy_bullet
- **effects**: shield_left, shield_right

### パレット切り替え
右上のドロップダウンで以下のステージパレットを切り替え可能：
- GRASSLAND（デフォルト）
- CAVE

## 確認方法
1. `npm run dev` でローカルサーバーを起動
2. `http://localhost:3000/sprite-debug.html` にアクセス
3. 全スプライトが表示されることを確認
4. パレット切り替えが動作することを確認

## スクリーンショット
※ 実際の動作画面は開発サーバーでご確認ください

## 関連Issue
- Closes #283

🤖 Generated with [Claude Code](https://claude.ai/code)